### PR TITLE
Additional point for the discussion card owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,13 @@ The game can be both played in "Blitz" mode or "Debate" mode; each of these mode
 3.  The Card Czar then pull a black prompt card and reads it to the group.
 4.  All other players then put 1 white response card face down in their slot.
 5.  The Card Czar then flips and reads each white card out loud.
-6.  The Card Czar then picks one of the white cards to further discuss. +1 point goes to the player whose card was chosen.
-7.  The group then discusses further what else could go wrong based on the chosen card. People can award +1 point anyone who makes a good point in discussion. Each response has prompts to lead the discussion.
-8.  The group's discussion for each round cannot exceed a certain time: 10 minutes for "Debate" mode, 5 minutes for "Blitz", to ensure a good flow.
-9.  The player whose white response was chosen by the Czar, draws one challenge card and assigns the completion of the challenge to another player.
-10. After the challenge, the next player becomes the Card Czar and clicks the "Deal" button. Each player then draws a new white card, so that they again have 5 cards in their hand.
-11. The game ends when a player reaches : 8 points for "Debate" mode, 5 points for "Blitz" mode.
+6.  The Card Czar then picks one of the white cards to further discuss. +1 point goes to the player whose card was chosen, he is now considered as the winner of the round.
+7.  The group then discusses further what else could go wrong based on the chosen card. People award +1 point for the player who has the best arguments in discussion. 
+8. The round winner also votes for his/her favorite among the 5 remaining players. If it matchs the community vote, this person  obtains an additional point as a reward since his point of view match the group's one. Each response has prompts to lead the discussion.
+9.  The group's discussion for each round cannot exceed a certain time: 10 minutes for "Debate" mode, 5 minutes for "Blitz", to ensure a good flow.
+10.  The player whose white response was chosen by the Czar, draws one challenge card and assigns the completion of the challenge to another player.
+11. After the challenge, the next player becomes the Card Czar and clicks the "Deal" button. Each player then draws a new white card, so that they again have 5 cards in their hand.
+12. The game ends when a player reaches : 8 points for "Debate" mode, 5 points for "Blitz" mode.
 
 ### During the game
 

--- a/main.tex
+++ b/main.tex
@@ -83,11 +83,12 @@
         \item The Card Czar then pulls a prompt card (\faicon{tasks}) and reads it to the group.
         \item All other players then put 1 event card face down on the table.   
         \item The Card Czar then flips and reads each white card out loud.
-        \item The Card Czar then picks one of the event cards to further discuss. +1 point goes to the player whose card was chosen.
-        \item The group then discusses further what else could go wrong based on the chosen card. People can award +1 point anyone who makes a good point in discussion. Each response card has prompts to lead the discussion.
-	      \item The group's discussion for each round cannot exceed a certain time: 10 minutes for "Debate" mode, 5 minutes for "Blitz", to ensure a good flow.
+        \item The Card Czar then picks one of the event cards to further discuss. +1 point goes to the player whose card was chosen, he is now considered as the winner of the round.
+        \item The group then discusses further what else could go wrong based on the chosen card. People award +1 point for the player who has the best arguments in discussion. 
+        \item The round winner also votes for his/her favorite among the 5 remaining players. If it matchs the community vote, this person  obtains an additional point as a reward since his point of view match the group's one. Each response has prompts to lead the discussion.
+	    \item The group's discussion for each round cannot exceed a certain time: 10 minutes for "Debate" mode, 5 minutes for "Blitz", to ensure a good flow.
         \item After the discussion dissipates after a few minutes, another player becomes the Card Czar based on the throw of a dice. Each player then draws a new white card, so that they again have 5 cards in their hand.
-	      \item The game ends when a player reaches : 8 points for "Debate" mode, 5 points for "Blitz" mode.
+	    \item The game ends when a player reaches : 8 points for "Debate" mode, 5 points for "Blitz" mode.
 
     \end{enumerate}
     \end{multicols}


### PR DESCRIPTION
My idea is to reward with an extra point the discussion card owner if his/her point of view is aligned with the community one. It urges people to envy this position where you can gain points point easier. As a result, they won't submit an uninteresting topic otherwise, they will be less likely to obtain points.

PS : the 5 remaining players give only ONE point and discuss to choose to whom. If plenty players have good arguments, they must decide